### PR TITLE
Reduce letter-frequency bias in Blossom board generator

### DIFF
--- a/assets/blossom/gen.js
+++ b/assets/blossom/gen.js
@@ -119,6 +119,23 @@
     const genByFirst = {};
     for (const w of genPool) (genByFirst[w[0]] ||= []).push(w);
 
+    // Per-letter correction factors: up-weight candidates ending on letters
+    // that are common chain-starters in the pool, down-weight those ending on
+    // letters that are rare starters. Applied to the next-word weight so the
+    // Markov chain's stationary distribution tracks the pool's first-letter
+    // distribution instead of its last-letter distribution.
+    const poolFirstCount = {};
+    const poolLastCount = {};
+    for (const w of genPool) {
+      poolFirstCount[w[0]] = (poolFirstCount[w[0]] || 0) + 1;
+      poolLastCount[w[w.length - 1]] = (poolLastCount[w[w.length - 1]] || 0) + 1;
+    }
+    const corrFactor = {};
+    for (const l in poolLastCount) {
+      corrFactor[l] =
+        ((poolFirstCount[l] || 0) + 1e-9) / (poolLastCount[l] + 1e-9);
+    }
+
     // The rng is threaded continuously through every decision below — seed
     // word, each subsequent word, and every tile placement all draw from this
     // one stream. That's why two different dates never produce the same board
@@ -235,7 +252,7 @@
           -(lengthCounts[w.length] || 0),
         );
         const lw = lengthWeight[w.length] != null ? lengthWeight[w.length] : 1;
-        return (local * local + 0.5) * lengthBonus * lw;
+        return (local * local + 0.5) * lengthBonus * lw * (corrFactor[w[w.length - 1]] || 1);
       });
       const ordered = weightedShuffle(candidates, weights, rng);
 


### PR DESCRIPTION
## Problem

The generator builds the chain forward: each word must start with the last letter of the previous word (e.g. BLOOM → **M**ELON → **N**IGHT). This means the starting letter of each new word is determined by whatever letter the previous word happened to end on.

The trouble is that letter frequencies aren't symmetric. E ends ~24% of pool words but starts only ~5% of them. So whenever a chain lands on a word ending in E, the next slot is forced to start with E — a letter that only a small fraction of the pool actually covers. Over a full board, words starting with E appear ~22% of the time even though only 5% of pool words start with E. The same over-representation affects other common word-endings like S, T, and Y.

In short: the boards are biased toward letters that words commonly end on, not letters that words commonly start on.

## Fix

Two additions to `generateBoard` in `assets/blossom/gen.js`, nothing else changed:

1. Compute a per-letter correction factor before the RNG is initialised:
   ```js
   corrFactor[l] = first_freq[l] / last_freq[l]
   ```
2. Multiply it into each candidate word's existing weight inside `extend()`:
   ```js
   return (local * local + 0.5) * lengthBonus * lw * (corrFactor[w[w.length - 1]] || 1);
   ```

This biases word selection toward words that end on letters which are naturally common starters, counteracting the skew. Board layout, tile-placement logic, `localRadius`, `overlapDecay`, length weights, and backtracking are all unchanged.

## Result (1 000 boards each, real generator)

TVD from pool first-letter distribution: **0.47 → 0.16 (3× improvement)**

![Before vs after letter-frequency correction](https://i.imgur.com/vA4M91j.png)

## Example boards

10 example boards (seeds 0–9): https://gist.github.com/aalec/ba70c21dae4ecadbde450e242cde0984