### PR TITLE
Fix localRadius: simulate greedy placer path instead of hex-distance set

### DIFF
--- a/assets/blossom/gen.js
+++ b/assets/blossom/gen.js
@@ -113,7 +113,7 @@
     const overlapDecay = opts.overlapDecay != null ? opts.overlapDecay : 0.8;
     // Floor weight for words with no local overlap. Controls how aggressively
     // the overlap signal crowds out non-overlapping candidates.
-    const overlapFloor = opts.overlapFloor != null ? opts.overlapFloor : 0.5;
+    const overlapFloor = opts.overlapFloor != null ? opts.overlapFloor : 0.3;
     const targetLetters = targetTiles * 1.5;
     // Runaway guard: cap total word-placement attempts across all backtracking
     // before giving up and reseeding. Normal generation never approaches this.

--- a/assets/blossom/gen.js
+++ b/assets/blossom/gen.js
@@ -102,7 +102,7 @@
     // Intrinsic per-length preference, applied on top of lengthAlpha. Lengths
     // absent from the map default to 1. The short (3) and long (8) extremes are
     // damped so they sprinkle in for variety without dominating the mix.
-    const lengthWeight = opts.lengthWeight || { 3: 0.4, 8: 0.4 };
+    const lengthWeight = opts.lengthWeight || { 4: 0.75, 5: 0.9, 7: 1.15, 8: 0.5 };
     // Localized-overlap weighting. When picking the next word, we reward letters
     // that can reuse a tile already sitting near the junction (the last placed
     // cell) — and reward the word's *earliest* letters most, since those are the
@@ -111,6 +111,9 @@
     // generation and let the final words wrap the rim on fresh tiles.
     const localRadius = opts.localRadius != null ? opts.localRadius : 2;
     const overlapDecay = opts.overlapDecay != null ? opts.overlapDecay : 0.8;
+    // Floor weight for words with no local overlap. Controls how aggressively
+    // the overlap signal crowds out non-overlapping candidates.
+    const overlapFloor = opts.overlapFloor != null ? opts.overlapFloor : 0.5;
     const targetLetters = targetTiles * 1.5;
     // Runaway guard: cap total word-placement attempts across all backtracking
     // before giving up and reseeding. Normal generation never approaches this.
@@ -279,7 +282,7 @@
           -(lengthCounts[w.length] || 0),
         );
         const lw = lengthWeight[w.length] != null ? lengthWeight[w.length] : 1;
-        return (local * local + 0.5) * lengthBonus * lw * (corrFactor[w[w.length - 1]] || 1);
+        return (local * local + overlapFloor) * lengthBonus * lw * (corrFactor[w[w.length - 1]] || 1);
       });
       const ordered = weightedShuffle(candidates, weights, rng);
 

--- a/assets/blossom/gen.js
+++ b/assets/blossom/gen.js
@@ -229,23 +229,50 @@
       const candidates = (genByFirst[last] || []).filter((w) => !used.has(w));
       if (!candidates.length) return tiles.size >= minTiles;
 
-      // Letters sitting on tiles within localRadius of the junction (the last
-      // placed cell). A candidate whose early letters land in this set can fold
-      // back onto an existing tile instead of extending the rim. Unlike the old
-      // whole-board letter set this stays selective late in generation, when the
-      // board already contains most of the alphabet.
+      // Simulate the greedy placer's path from the junction, assuming no tile
+      // reuse occurs (i.e. each step lands on a fresh empty cell). placeLetter
+      // always picks the empty neighbour with the most filled neighbours, ties
+      // broken by proximity to center — we run that same deterministic rule to
+      // predict where the placer would be at each word position li. The letters
+      // on actual board tiles adjacent to predictedPath[li-1] are then exactly
+      // the set the placer CAN reuse at step li.
+      //
+      // This replaces the old hex-distance localSet approach, which credited
+      // letters on tiles the placer couldn't actually reach at that position,
+      // causing larger localRadius values to counterintuitively reduce overlap.
       const junction = seq[seq.length - 1].cellIdx;
-      const localSet = new Set();
-      for (const [cell, letter] of tiles) {
-        if (hexDistance(cell, junction) <= localRadius) localSet.add(letter);
+      const predictedPath = [junction];
+      const predOccupied = new Set(tiles.keys());
+      for (let li = 1; li <= localRadius; li++) {
+        const prev = predictedPath[li - 1];
+        let best = -1, bestFilled = -1, bestDist = Infinity;
+        for (const n of neighbors(prev)) {
+          if (predOccupied.has(n)) continue;
+          const filled = neighbors(n).filter(x => predOccupied.has(x)).length;
+          const dist = hexDistance(n, start);
+          if (filled > bestFilled || (filled === bestFilled && dist < bestDist)) {
+            bestFilled = filled; bestDist = dist; best = n;
+          }
+        }
+        if (best < 0) break;
+        predictedPath.push(best);
+        predOccupied.add(best);
+      }
+      // localReachable[li-1] = letters on board tiles adjacent to the predicted
+      // cell at step li-1, i.e. the letters reusable by the placer at position li.
+      const localReachable = [];
+      for (let li = 1; li < predictedPath.length; li++) {
+        const reachable = new Set();
+        for (const n of neighbors(predictedPath[li - 1])) {
+          if (tiles.has(n)) reachable.add(tiles.get(n));
+        }
+        localReachable.push(reachable);
       }
       const weights = candidates.map((w) => {
-        // Credit each reusable letter, decaying by position so a match on the
-        // word's 2nd letter (first one placed after the shared joint) counts
-        // most. w[0] is the shared joint, so start at index 1.
         let local = 0;
         for (let li = 1; li < w.length; li++) {
-          if (localSet.has(w[li])) local += Math.pow(overlapDecay, li - 1);
+          const reachable = localReachable[li - 1];
+          if (reachable && reachable.has(w[li])) local += Math.pow(overlapDecay, li - 1);
         }
         const lengthBonus = Math.pow(
           1 + lengthAlpha,


### PR DESCRIPTION
## Summary

Three related changes to `gen.js`:

1. **Radius fix** — replaces the hex-distance `localSet` overlap signal with a simulation of the greedy placer's actual path. The old approach credited letters on tiles the placer couldn't reach at that position, causing larger `localRadius` values to *reduce* overlap. Now `localRadius` = steps of look-ahead, and larger values correctly produce more overlap opportunity.

2. **`overlapFloor` param** — extracts the hardcoded `0.5` floor in `(local² + 0.5)` into `opts.overlapFloor` (default `0.3`). Controls how strongly the overlap signal crowds out non-overlapping candidates. Lowered from `0.5` to `0.3` to restore overlap rate after the lengthWeight re-tune.

3. **`lengthWeight` re-tune** — the radius fix alone shifts the word-length mix toward shorter words (accurate per-position signals favour short words whose early letters land on reachable tiles). The new defaults `{ 4: 0.75, 5: 0.90, 7: 1.15, 8: 0.50 }` restore avg word length to ~5.80 (was 5.79 before the fix).

All existing board seeds continue to produce valid boards.

## Before / After (500 boards, defaults: localRadius=2, overlapDecay=0.8)

```
                          BEFORE       AFTER
words/board:         6.01 ± 0.56    5.98 ± 0.53
tiles/board:         24.07 ± 2.96   23.93 ± 2.69
overlap rate:        18.5 ± 9.1%    19.0 ± 8.0%

words per board by length:
  4-letter:          1.38 ± 0.93  1.35 ± 0.88   (~)
  5-letter:          1.31 ± 0.80  1.34 ± 0.83   (~)
  6-letter:          1.41 ± 0.82  1.35 ± 0.79   (~)
  7-letter:          1.28 ± 0.82  1.20 ± 0.73   (~)
  8-letter:          0.64 ± 0.67  0.74 ± 0.68   (~)
  avg word length:   5.79 ± 0.48  5.80 ± 0.46   (≈)

inter-word depth-1:       3.358        3.750    ↑
inter-word depth-2:       1.296        1.498    ↑
inter-word depth-3:       0.476        0.464
inter-word depth-4:       0.144        0.124
inter-word depth-5:       0.060        0.046
intra-word depth-1:       0.828        0.778
intra-word depth-2:       0.114        0.078
```

Word-length mix and avg word length are approximately a wash. Overlap rate is restored to ~19% (within noise of the 18.5% baseline). Depth-1 and depth-2 inter-word reuse increase because the signal now accurately rewards achievable overlaps rather than phantom ones.

## Sample boards

10 example boards showing word-count variety (3× 5-word, 3× 6-word, 3× 7-word, 1× 8-word): https://gist.github.com/aalec/ff2edb69568ca4ae047f1ced8d0e7f1c

🤖 Generated with [Claude Code](https://claude.com/claude-code)